### PR TITLE
Add Debian 13 Trixie builds and modernize scripts/CI 

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,33 +1,41 @@
 name: docker-hub
 on:
   push:
-    branches: main
+    branches:
+      - main
   schedule:
-    - cron: '1 */24 * * *'
+    - cron: "1 0 * * *"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker-hub:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      # Install requred packages
+      # Install required packages
       - name: Install apt packages
-        run: sudo apt-get install -y jq moreutils
+        run: sudo apt-get install -y jq
       # Checkout repository
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       # Login to Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       # Run script that checks for new versions and triggers builds
       - name: Run build script
         run: ./script.sh fetch --verbose
-      # Commit data.json file if changed detected
+      # Commit data.json file if changes detected
       - name: Commit data.json metadata file
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update data.json file with new versions
           branch: main

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Based on [`v3.0.2` version of gost-engine](https://github.com/gost-engine/engine
 - [`ecp_id_GostR3410_2001_CryptoPro_B_ParamSet`](https://github.com/gost-engine/engine/blob/v3.0.2/ecp_id_GostR3410_2001_CryptoPro_B_ParamSet.c)
 - [`ecp_id_GostR3410_2001_CryptoPro_C_ParamSet`](https://github.com/gost-engine/engine/blob/v3.0.2/ecp_id_GostR3410_2001_CryptoPro_C_ParamSet.c)
 
-2. **Create a Certificate Signing Request (CSR)**: Generate a CSR using the private key you created in the previous step:
+1. **Create a Certificate Signing Request (CSR)**: Generate a CSR using the private key you created in the previous step:
 
 ```shell
 openssl req -new -key cert.key -out cert.csr \
   -subj "/C=RU/ST=Moscow_Olast/L=Moscow/O=Big_Brother_LTD/OU=IT/CN=bigbrother.ru/emailAddress=donos@bigbrother.ru"
 ```
 
-3. **Generate a Self-Signed Certificate**: Now, use the private key and CSR to generate a self-signed certificate.
+1. **Generate a Self-Signed Certificate**: Now, use the private key and CSR to generate a self-signed certificate.
 
 ```shell
 openssl x509 -req -days 365 -in cert.csr -signkey cert.key -out cert.pem
@@ -69,7 +69,7 @@ openssl x509 -req -days 365 -in cert.csr -signkey cert.key -out cert.pem
 
 This command will create a self-signed certificate valid for 365 days.
 
-4. **Verify the Certificate** (Optional): You can verify the details of the generated certificate using the following command:
+1. **Verify the Certificate** (Optional): You can verify the details of the generated certificate using the following command:
 
 ```shell
 openssl x509 -in cert.pem -text -noout

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ The `mbrav/docker-gost` repository is tagged with the following scheme where `x.
 - **Debian 12 ("*Bookworm*") with Nginx**:
   - Tags: `bookworm-nginx`, `bookworm-nginx-x.x.x`, `bookworm-nginx-x.x.x-y.y.y`, `nginx`, `nginx-x.x.x`, `nginx-x.x.x-y.y.y`
   - Dockerfile: [debian-bookworm/nginx.Dockerfile](https://github.com/mbrav/docker-gost/blob/main/debian-bookworm/nginx.Dockerfile)
+- **Debian 13 ("*Trixie*")**:
+  - Tags: `trixie`, `trixie-x.x.x`
+  - Dockerfile: [debian-trixie/Dockerfile](https://github.com/mbrav/docker-gost/blob/main/debian-trixie/Dockerfile)
+- **Debian 13 ("*Trixie*") with Nginx**:
+  - Tags: `trixie-nginx`, `trixie-nginx-x.x.x`, `trixie-nginx-x.x.x-y.y.y`
+  - Dockerfile: [debian-trixie/nginx.Dockerfile](https://github.com/mbrav/docker-gost/blob/main/debian-trixie/nginx.Dockerfile)
 - **Alpine 3**:
   - Tags: `alpine`, `alpine-x.x.x`
   - Dockerfile: [alpine/Dockerfile](https://github.com/mbrav/docker-gost/blob/main/alpine/Dockerfile)

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3 as builder
+FROM alpine:3 AS builder
 
 # Install build requirements
 RUN apk add --upgrade --latest busybox alpine-sdk cmake linux-headers unzip perl

--- a/alpine/nginx.Dockerfile
+++ b/alpine/nginx.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3 as builder
+FROM alpine:3 AS builder
 
 # Install build requirements
 RUN apk add --upgrade --latest busybox alpine-sdk cmake linux-headers unzip perl

--- a/data.json
+++ b/data.json
@@ -27,6 +27,23 @@
         "nginx-%%openssl%%",
         "nginx-%%openssl%%-%%nginx%%"
       ]
+    },
+    {
+      "name": "trixie",
+      "dockerfile": "debian-trixie/Dockerfile",
+      "tags": [
+        "trixie",
+        "trixie-%%openssl%%"
+      ]
+    },
+    {
+      "name": "trixie-nginx",
+      "dockerfile": "debian-trixie/nginx.Dockerfile",
+      "tags": [
+        "trixie-nginx",
+        "trixie-nginx-%%openssl%%",
+        "trixie-nginx-%%openssl%%-%%nginx%%"
+      ]
     }
   ]
 }

--- a/debian-bookworm/Dockerfile
+++ b/debian-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as builder
+FROM debian:bookworm-slim AS builder
 
 # Install build requirements
 RUN apt-get update \

--- a/debian-trixie/Dockerfile
+++ b/debian-trixie/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 
 # Install build requirements
 RUN apt-get update \
@@ -6,12 +6,12 @@ RUN apt-get update \
 
 ARG OPENSSL_VERSION="openssl-${OPENSSL_VERSION:-3.3.0}"
 ARG NGINX_VERSION="${NGINX_VERSION:-1.25.4}"
-ENV OPENSSL_DIR="/usr/local/ssl" 
+ENV OPENSSL_DIR="/usr/local/ssl"
 ENV OPENSSL_LIB="/usr/local/lib64"
 ENV OPENSSL_ENGINES="/usr/local/lib64/engines-3"
 ENV OPENSSL_INCLUDES="/usr/local/include/openssl"
 
-# Download OpenSSL with GOST TLS git module 
+# Download OpenSSL with GOST TLS git module
 RUN mkdir -p /usr/local/src \
   && cd /usr/local/src \
   && git clone -b "${OPENSSL_VERSION}" --depth 1 https://github.com/openssl/openssl.git "${OPENSSL_VERSION}" \
@@ -65,73 +65,7 @@ RUN touch "${OPENSSL_DIR}/openssl.cnf" \
   && echo "" >> "${OPENSSL_DIR}/openssl.cnf" \
   && cp "${OPENSSL_DIR}/openssl.cnf" /etc/ssl/openssl.cnf
 
-# Install build requirements for nginx
-RUN apt-get update \
-  && apt-get install libpcre2-dev libz-dev --no-install-recommends -y
-
-# Download nginx
-RUN cd /usr/local/src \
-  && curl -L -o "nginx-${NGINX_VERSION}.tar.gz" "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" \
-  && tar -zxvf "nginx-${NGINX_VERSION}.tar.gz" \
-  && rm "nginx-${NGINX_VERSION}.tar.gz"
-
-# Build nginx 
-RUN cd "/usr/local/src/nginx-${NGINX_VERSION}" \
-  && ./configure \
-  --prefix=/etc/nginx \
-  --sbin-path=/usr/sbin/nginx \
-  --modules-path=/usr/lib/nginx/modules \
-  --conf-path=/etc/nginx/nginx.conf \
-  --error-log-path=/var/log/nginx/error.log \
-  --http-log-path=/var/log/nginx/access.log \
-  --pid-path=/var/run/nginx.pid \
-  --lock-path=/var/run/nginx.lock \
-  --http-client-body-temp-path=/var/cache/nginx/client_temp \
-  --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
-  --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
-  --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
-  --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
-  --user=www-data \
-  --group=www-data \
-  --with-compat \
-  --with-file-aio \
-  --with-threads \
-  --with-http_addition_module \
-  --with-http_auth_request_module \
-  --with-http_dav_module \
-  --with-http_flv_module \
-  --with-http_gunzip_module \
-  --with-http_gzip_static_module \
-  --with-http_mp4_module \
-  --with-http_random_index_module \
-  --with-http_realip_module \
-  --with-http_secure_link_module \
-  --with-http_slice_module \
-  --with-http_ssl_module \
-  --with-http_stub_status_module \
-  --with-http_sub_module \
-  --with-http_v2_module \
-  --with-mail \
-  --with-mail_ssl_module \
-  --with-stream \
-  --with-stream_realip_module \
-  --with-stream_ssl_module \
-  --with-stream_ssl_preread_module \
-  --with-openssl="/usr/local/src/${OPENSSL_VERSION}" \
-  && make -j "$(nproc)" \
-  && make install \
-  && mkdir -p \
-  /var/cache/nginx/client_temp \
-  /var/cache/nginx/proxy_temp \
-  /var/cache/nginx/fastcgi_temp \
-  /var/cache/nginx/uwsgi_temp \
-  /var/cache/nginx/scgi_temp \
-  # Forward request and error logs to docker log collector
-  && touch /var/log/nginx/access.log /var/log/nginx/error.log \
-  && ln -sf /dev/stdout /var/log/nginx/access.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
-
-# Clean 
+# Clean
 RUN apt-get remove build-essential cmake curl unzip git --purge --auto-remove -y \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /usr/local/src/*
@@ -139,10 +73,6 @@ RUN apt-get remove build-essential cmake curl unzip git --purge --auto-remove -y
 # Create a squashed image
 FROM scratch
 
-COPY --from=builder / /
-
-STOPSIGNAL SIGTERM
-
 WORKDIR /root
 
-CMD ["nginx", "-g", "daemon off;"]
+COPY --from=builder / /

--- a/debian-trixie/nginx.Dockerfile
+++ b/debian-trixie/nginx.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 
 # Install build requirements
 RUN apt-get update \
@@ -6,12 +6,12 @@ RUN apt-get update \
 
 ARG OPENSSL_VERSION="openssl-${OPENSSL_VERSION:-3.3.0}"
 ARG NGINX_VERSION="${NGINX_VERSION:-1.25.4}"
-ENV OPENSSL_DIR="/usr/local/ssl" 
+ENV OPENSSL_DIR="/usr/local/ssl"
 ENV OPENSSL_LIB="/usr/local/lib64"
 ENV OPENSSL_ENGINES="/usr/local/lib64/engines-3"
 ENV OPENSSL_INCLUDES="/usr/local/include/openssl"
 
-# Download OpenSSL with GOST TLS git module 
+# Download OpenSSL with GOST TLS git module
 RUN mkdir -p /usr/local/src \
   && cd /usr/local/src \
   && git clone -b "${OPENSSL_VERSION}" --depth 1 https://github.com/openssl/openssl.git "${OPENSSL_VERSION}" \
@@ -75,7 +75,7 @@ RUN cd /usr/local/src \
   && tar -zxvf "nginx-${NGINX_VERSION}.tar.gz" \
   && rm "nginx-${NGINX_VERSION}.tar.gz"
 
-# Build nginx 
+# Build nginx
 RUN cd "/usr/local/src/nginx-${NGINX_VERSION}" \
   && ./configure \
   --prefix=/etc/nginx \
@@ -131,7 +131,7 @@ RUN cd "/usr/local/src/nginx-${NGINX_VERSION}" \
   && ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
 
-# Clean 
+# Clean
 RUN apt-get remove build-essential cmake curl unzip git --purge --auto-remove -y \
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /usr/local/src/*

--- a/examples/nginx-gost/README.md
+++ b/examples/nginx-gost/README.md
@@ -1,12 +1,75 @@
-# Nginx with Gost TLS example
+# Nginx with GOST TLS example
 
-This is an example that shows how to create an nginx server that accepts only GOST TLS algorithms. It consists of the following componenets:
+An end-to-end example of an nginx server that serves HTML content secured with
+a self-signed GOST 2012 certificate, plus a cleartext proxy so a standard
+browser can reach the page without needing native GOST cipher support.
 
-- **Server** - Nginx server that can only accept GOST TLS connections;
-- **Proxy** - An Nginx that serves contents from server with cleartext.
+## Architecture
+
+```
+Browser / curl
+    │  HTTP :8080
+    ▼
+┌─────────┐    GOST TLS :443    ┌─────────┐
+│  proxy  │ ──────────────────► │  server │
+│ (nginx) │                     │ (nginx) │
+└─────────┘                     └─────────┘
+mbrav/docker-gost:bookworm-nginx (both services)
+```
+
+- **server** — nginx listening on port 443 with GOST TLS. Serves `html/index.html`.
+  A self-signed GOST 2012 certificate is generated automatically on first start
+  and stored in a named Docker volume (`certs`).
+- **proxy** — nginx listening on port 8080 (plain HTTP). Connects to `server:443`
+  over GOST TLS and re-serves the content in cleartext for regular clients.
 
 ## Running
 
 ```shell
-docker-compose up
+docker compose up
+```
+
+Then open <http://localhost:8080> in a browser.
+
+## Direct GOST TLS access
+
+To connect directly to the server over GOST TLS (requires a GOST-capable
+OpenSSL, e.g. inside the container):
+
+```shell
+docker compose exec server openssl s_client \
+  -connect localhost:443 \
+  -cipher GOST2012-KUZNYECHIK-KUZNYECHIKOMAC \
+  </dev/null
+```
+
+## File layout
+
+```
+examples/nginx-gost/
+├── docker-compose.yml          # service definitions
+├── entrypoint.sh               # cert generation + nginx start for the server
+├── nginx/
+│   ├── server.nginx.conf       # GOST TLS server config
+│   └── proxy.nginx.conf        # cleartext reverse-proxy config
+└── html/
+    └── index.html              # page served by the server
+```
+
+## Certificate details
+
+The entrypoint generates a GOST 2012 self-signed certificate on first start:
+
+| Field     | Value                         |
+|-----------|-------------------------------|
+| Algorithm | `gost2012_256`                |
+| Paramset  | `A`                           |
+| Validity  | 365 days                      |
+| Subject   | `CN=localhost, O=docker-gost` |
+
+To regenerate the certificate, remove the Docker volume:
+
+```shell
+docker compose down -v
+docker compose up
 ```

--- a/examples/nginx-gost/docker-compose.yml
+++ b/examples/nginx-gost/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  # Nginx server: serves HTML over HTTPS using a self-signed GOST 2012 certificate.
+  # The entrypoint generates the certificate on first start and stores it in the
+  # shared 'certs' volume so the proxy can also reach the server over GOST TLS.
+  server:
+    image: mbrav/docker-gost:bookworm-nginx
+    entrypoint: ["/bin/bash", "/scripts/entrypoint.sh"]
+    volumes:
+      - certs:/etc/nginx/certs
+      - ./entrypoint.sh:/scripts/entrypoint.sh:ro
+      - ./nginx/server.nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./html:/var/www/html:ro
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >
+          openssl s_client
+          -connect localhost:443
+          -cipher GOST2012-KUZNYECHIK-KUZNYECHIKOMAC
+          </dev/null 2>/dev/null | grep -q CONNECTED
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
+  # Cleartext proxy: listens on port 8080, proxies requests to the server over
+  # GOST TLS, and re-serves them in plain HTTP so a regular browser can reach
+  # the content without needing GOST cipher support.
+  proxy:
+    image: mbrav/docker-gost:bookworm-nginx
+    volumes:
+      - ./nginx/proxy.nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8080:80"
+    depends_on:
+      server:
+        condition: service_healthy
+
+volumes:
+  certs:

--- a/examples/nginx-gost/entrypoint.sh
+++ b/examples/nginx-gost/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+CERT_DIR="/etc/nginx/certs"
+CERT_KEY="${CERT_DIR}/server.key"
+CERT_CRT="${CERT_DIR}/server.crt"
+
+mkdir -p "$CERT_DIR"
+
+if [[ ! -f "$CERT_CRT" ]]; then
+    echo "[i] Generating self-signed GOST 2012 certificate..."
+
+    # Step 1: generate a GOST 2012 private key (256-bit, parameter set A)
+    openssl genpkey \
+        -algorithm gost2012_256 \
+        -pkeyopt paramset:A \
+        -out "$CERT_KEY"
+
+    # Step 2: create a certificate signing request
+    openssl req -new \
+        -key "$CERT_KEY" \
+        -out "${CERT_DIR}/server.csr" \
+        -subj "/C=RU/ST=Moscow/L=Moscow/O=docker-gost/CN=localhost"
+
+    # Step 3: self-sign the certificate (valid for 365 days)
+    openssl x509 -req \
+        -days 365 \
+        -in "${CERT_DIR}/server.csr" \
+        -signkey "$CERT_KEY" \
+        -out "$CERT_CRT"
+
+    rm -f "${CERT_DIR}/server.csr"
+
+    echo "[✓] Certificate generated: $CERT_CRT"
+else
+    echo "[✓] Certificate already exists: $CERT_CRT"
+fi
+
+exec nginx -g "daemon off;"

--- a/examples/nginx-gost/html/index.html
+++ b/examples/nginx-gost/html/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>docker-gost — GOST TLS demo</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f1923;
+      color: #d0d8e4;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+
+    .card {
+      background: #1a2535;
+      border: 1px solid #2a3a50;
+      border-radius: 10px;
+      max-width: 680px;
+      width: 100%;
+      padding: 2.5rem 3rem;
+    }
+
+    .badge {
+      display: inline-block;
+      background: #1a6b3c;
+      color: #7effc0;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 0.3em 0.8em;
+      border-radius: 4px;
+      margin-bottom: 1.2rem;
+    }
+
+    h1 {
+      font-size: 1.9rem;
+      color: #eaf0fb;
+      margin-bottom: 0.6rem;
+    }
+
+    .subtitle {
+      color: #7a90aa;
+      margin-bottom: 2rem;
+      line-height: 1.6;
+    }
+
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: #9ab0cc;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin: 1.8rem 0 0.6rem;
+    }
+
+    pre {
+      background: #0f1923;
+      border: 1px solid #2a3a50;
+      border-radius: 6px;
+      padding: 1rem 1.2rem;
+      font-size: 0.85rem;
+      color: #7effc0;
+      overflow-x: auto;
+      line-height: 1.6;
+    }
+
+    .ciphers {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      margin-top: 0.6rem;
+    }
+
+    .cipher {
+      background: #0f1923;
+      border: 1px solid #2a3a50;
+      border-radius: 4px;
+      padding: 0.25em 0.6em;
+      font-family: monospace;
+      font-size: 0.78rem;
+      color: #7bb8f5;
+    }
+
+    footer {
+      margin-top: 2.5rem;
+      font-size: 0.78rem;
+      color: #4a6070;
+      border-top: 1px solid #2a3a50;
+      padding-top: 1rem;
+    }
+
+    footer a { color: #5a8fa8; text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">GOST TLS Active</div>
+    <h1>Hello from docker-gost!</h1>
+    <p class="subtitle">
+      This page is served by <strong>nginx</strong> compiled against OpenSSL with the
+      <a href="https://github.com/gost-engine/engine" style="color:#7bb8f5">gost-engine</a>
+      submodule. The connection between the proxy and this server is secured with a
+      self-signed <strong>GOST 2012</strong> certificate.
+    </p>
+
+    <h2>Inspect the certificate</h2>
+    <pre>openssl s_client \
+  -connect localhost:443 \
+  -cipher GOST2012-KUZNYECHIK-KUZNYECHIKOMAC \
+  &lt;/dev/null</pre>
+
+    <h2>Verify available GOST ciphers</h2>
+    <pre>openssl ciphers | tr ':' '\n' | grep GOST</pre>
+
+    <h2>Active cipher suites</h2>
+    <div class="ciphers">
+      <span class="cipher">GOST2012-MAGMA-MAGMAOMAC</span>
+      <span class="cipher">GOST2012-KUZNYECHIK-KUZNYECHIKOMAC</span>
+      <span class="cipher">LEGACY-GOST2012-GOST8912-GOST8912</span>
+      <span class="cipher">GOST2001-GOST89-GOST89</span>
+    </div>
+
+    <footer>
+      <a href="https://github.com/mbrav/docker-gost">mbrav/docker-gost</a>
+      &mdash; OpenSSL + GOST engine Docker images
+    </footer>
+  </div>
+</body>
+</html>

--- a/examples/nginx-gost/nginx/proxy.nginx.conf
+++ b/examples/nginx-gost/nginx/proxy.nginx.conf
@@ -1,0 +1,32 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include      /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    sendfile     on;
+
+    # Use Docker's embedded DNS so the 'server' hostname resolves dynamically
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            # Connect to the upstream server over GOST TLS
+            proxy_pass              https://server:443;
+            proxy_ssl_verify        off;
+            proxy_ssl_protocols     TLSv1.2;
+            proxy_ssl_ciphers       GOST2012-MAGMA-MAGMAOMAC:GOST2012-KUZNYECHIK-KUZNYECHIKOMAC:LEGACY-GOST2012-GOST8912-GOST8912:GOST2001-GOST89-GOST89;
+
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/examples/nginx-gost/nginx/server.nginx.conf
+++ b/examples/nginx-gost/nginx/server.nginx.conf
@@ -1,0 +1,31 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include      /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    sendfile     on;
+
+    server {
+        listen 443 ssl;
+        server_name localhost;
+
+        ssl_certificate     /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+
+        # Accept only TLS 1.2 with GOST cipher suites
+        ssl_protocols             TLSv1.2;
+        ssl_ciphers               GOST2012-MAGMA-MAGMAOMAC:GOST2012-KUZNYECHIK-KUZNYECHIKOMAC:LEGACY-GOST2012-GOST8912-GOST8912:GOST2001-GOST89-GOST89;
+        ssl_prefer_server_ciphers on;
+
+        root  /var/www/html;
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }
+}

--- a/script.sh
+++ b/script.sh
@@ -9,319 +9,326 @@ script_command=fetch
 # COLORS
 ncolors=$(command -v tput >/dev/null && tput colors) # supports color
 if [[ -n $ncolors && -z $NO_COLOR ]]; then
-	TERMCOLS=$(tput cols)
-	CLEAR="$(tput sgr0)"
+  TERMCOLS=$(tput cols)
+  CLEAR="$(tput sgr0)"
 
-	# 4 bit colors
-	if test $ncolors -ge 8; then
-		# Normal
-		BLACK="$(tput setaf 0)"
-		RED="$(tput setaf 1)"
-		GREEN="$(tput setaf 2)"
-		YELLOW="$(tput setaf 3)"
-		BLUE="$(tput setaf 4)"
-		MAGENTA="$(tput setaf 5)"
-		CYAN="$(tput setaf 6)"
-		GREY="$(tput setaf 7)"
-	fi
+  # 4 bit colors
+  if test $ncolors -ge 8; then
+    # Normal
+    BLACK="$(tput setaf 0)"
+    RED="$(tput setaf 1)"
+    GREEN="$(tput setaf 2)"
+    YELLOW="$(tput setaf 3)"
+    BLUE="$(tput setaf 4)"
+    MAGENTA="$(tput setaf 5)"
+    CYAN="$(tput setaf 6)"
+    GREY="$(tput setaf 7)"
+  fi
 
-	# >4 bit colors
-	if test $ncolors -gt 8; then
-		# High intensity
-		BLACK_I="$(tput setaf 8)"
-		RED_I="$(tput setaf 9)"
-		GREEN_I="$(tput setaf 10)"
-		YELLOW_I="$(tput setaf 11)"
-		BLUE_I="$(tput setaf 12)"
-		MAGENTA_I="$(tput setaf 13)"
-		CYAN_I="$(tput setaf 14)"
-		WHITE="$(tput setaf 15)"
-	else
-		BLACK_I=$BLACK
-		RED_I=$RED
-		GREEN_I=$GREEN
-		YELLOW_I=$YELLOW
-		BLUE_I=$BLUE
-		MAGENTA_I=$MAGENTA
-		CYAN_I=$CYAN
-		WHITE=$GREY
-	fi
+  # >4 bit colors
+  if test $ncolors -gt 8; then
+    # High intensity
+    BLACK_I="$(tput setaf 8)"
+    RED_I="$(tput setaf 9)"
+    GREEN_I="$(tput setaf 10)"
+    YELLOW_I="$(tput setaf 11)"
+    BLUE_I="$(tput setaf 12)"
+    MAGENTA_I="$(tput setaf 13)"
+    CYAN_I="$(tput setaf 14)"
+    WHITE="$(tput setaf 15)"
+  else
+    BLACK_I=$BLACK
+    RED_I=$RED
+    GREEN_I=$GREEN
+    YELLOW_I=$YELLOW
+    BLUE_I=$BLUE
+    MAGENTA_I=$MAGENTA
+    CYAN_I=$CYAN
+    WHITE=$GREY
+  fi
 
-	# Styles
-	BOLD="$(tput bold)"
+  # Styles
+  BOLD="$(tput bold)"
 fi
 
 function error_msg() {
-	# Error message
-	# $1            - Message string argument
-	# $2 (optional) - exit code
-	echo -e "${RED}${BOLD}[X] ${1}${CLEAR}"
-	[[ -n $2 ]] && exit $2
+  # Error message
+  # $1            - Message string argument
+  # $2 (optional) - exit code
+  echo -e "${RED}${BOLD}[X] ${1}${CLEAR}"
+  [[ -n $2 ]] && exit $2
 }
 
 function warning_msg() {
-	echo -e "${YELLOW}${BOLD}[!] ${*}${CLEAR}"
+  echo -e "${YELLOW}${BOLD}[!] ${*}${CLEAR}"
 }
 
 function success_msg() {
-	echo -e "${GREEN}${BOLD}[✓] ${*}${CLEAR}"
+  echo -e "${GREEN}${BOLD}[✓] ${*}${CLEAR}"
 }
 
 function info_msg() {
-	# Info message if $verbose is set
-	[ -n "$verbose" ] && echo -e "${CYAN}[i] ${*}${CLEAR}"
+  # Info message if $verbose is set
+  [ -n "$verbose" ] && echo -e "${CYAN}[i] ${*}${CLEAR}"
 }
 
 # Display Help
 help() {
-	echo -e "${CYAN}${BOLD}Docker GOST multi script v${script_version}${CLEAR}"
-	echo
-	echo -e "${YELLOW}ABOUT${CLEAR}"
-	echo -e "Script for managing Docker GOST CI/Build process"
-	echo
-	echo -e "${YELLOW}SYNTAX${CLEAR}"
-	echo -e "./script.sh [build|fetch|all] [-h|v|n] [-p] [ARG]"
-	echo
-	echo -e "${YELLOW}EXAMPLE${CLEAR}"
-	echo -e "Build all docker images without pusshing with verbose output"
-	echo -e "./script.sh build --no-push -v"
-	echo
-	echo -e "${YELLOW}COMMANDS${CLEAR}"
-	echo -e "build               Build docker images."
-	echo -e "fetch               Fetch latest versions."
-	echo -e "fetch-openssl       Fetch latest openssl version and print to console."
-	echo -e "fetch-nginx         Fetch latest nginx version and print to console."
-	echo
-	echo -e "${YELLOW}OPTIONS${CLEAR}"
-	echo -e "-h --help           Print this Help."
-	echo -e "-v --verbose        Verbose output"
-	echo -e "-b --no-build       Don't trigger build if new version is available"
-	echo -e "-n --no-push        Don't push images, only build"
-	echo
-	echo -e "${GREEN}${TERMCOLS} colors ${CLEAR}"
+  echo -e "${CYAN}${BOLD}Docker GOST multi script v${script_version}${CLEAR}"
+  echo
+  echo -e "${YELLOW}ABOUT${CLEAR}"
+  echo -e "Script for managing Docker GOST CI/Build process"
+  echo
+  echo -e "${YELLOW}SYNTAX${CLEAR}"
+  echo -e "./script.sh [build|fetch|all] [-h|v|n] [-p] [ARG]"
+  echo
+  echo -e "${YELLOW}EXAMPLE${CLEAR}"
+  echo -e "Build all docker images without pusshing with verbose output"
+  echo -e "./script.sh build --no-push -v"
+  echo
+  echo -e "${YELLOW}COMMANDS${CLEAR}"
+  echo -e "build               Build docker images."
+  echo -e "fetch               Fetch latest versions."
+  echo -e "fetch-openssl       Fetch latest openssl version and print to console."
+  echo -e "fetch-nginx         Fetch latest nginx version and print to console."
+  echo
+  echo -e "${YELLOW}OPTIONS${CLEAR}"
+  echo -e "-h --help           Print this Help."
+  echo -e "-v --verbose        Verbose output"
+  echo -e "-b --no-build       Don't trigger build if new version is available"
+  echo -e "-n --no-push        Don't push images, only build"
+  echo
+  echo -e "${GREEN}${TERMCOLS} colors ${CLEAR}"
 }
 
 # ARG parser
 if [ $# -eq 0 ]; then
-	# If no arguments, display help
-	help
+  # If no arguments, display help
+  help
 else
-	while [ $# -gt 0 ]; do
-		case $1 in
-		build)
-			script_command=build
-			shift # shift argument
-			;;
-		fetch)
-			script_command=fetch
-			shift # shift argument
-			;;
-		fetch-openssl)
-			script_command=fetch-openssl
-			shift # shift argument
-			;;
-		fetch-nginx)
-			script_command=fetch-nginx
-			shift # shift argument
-			;;
-		--help | -h)
-			help
-			shift # shift argument
-			exit 0
-			;;
-		--verbose | -v)
-			verbose=true
-			shift # shift argument
-			;;
-		--no-build | -b)
-			no_build=true
-			shift # shift argument
-			;;
-		--no-push | -n)
-			no_push=true
-			shift # shift argument
-			;;
-		-*)
-			error_msg "Unknown option $1" 22
-			exit 1
-			;;
-		*)
-			error_msg "Unknown argument $1"
-			echo 'If you want to pass an argument with spaces'
-			echo 'pass the argument like this: "my argument"'
-			exit 1
-			;;
-		esac
-	done
+  while [ $# -gt 0 ]; do
+    case $1 in
+    build)
+      script_command=build
+      shift # shift argument
+      ;;
+    fetch)
+      script_command=fetch
+      shift # shift argument
+      ;;
+    fetch-openssl)
+      script_command=fetch-openssl
+      shift # shift argument
+      ;;
+    fetch-nginx)
+      script_command=fetch-nginx
+      shift # shift argument
+      ;;
+    --help | -h)
+      help
+      shift # shift argument
+      exit 0
+      ;;
+    --verbose | -v)
+      verbose=true
+      shift # shift argument
+      ;;
+    --no-build | -b)
+      no_build=true
+      shift # shift argument
+      ;;
+    --no-push | -n)
+      no_push=true
+      shift # shift argument
+      ;;
+    -*)
+      error_msg "Unknown option $1" 22
+      exit 1
+      ;;
+    *)
+      error_msg "Unknown argument $1"
+      echo 'If you want to pass an argument with spaces'
+      echo 'pass the argument like this: "my argument"'
+      exit 1
+      ;;
+    esac
+  done
 fi
 
 function build_images {
-	# Check for required commands
-	command -v jq >/dev/null || error_msg "Please install jq JSON parser package"
+  # Check for required commands
+  command -v jq >/dev/null || error_msg "Please install jq JSON parser package"
 
-	# Set versions
-	OPENSSL_VERSION=$(jq -r '.versions.openssl' data.json)
-	NGINX_VERSION=$(jq -r '.versions.nginx' data.json)
+  # Set versions
+  OPENSSL_VERSION=$(jq -r '.versions.openssl' data.json)
+  NGINX_VERSION=$(jq -r '.versions.nginx' data.json)
 
-	info_msg "Copying data.json"
-	cp -v "${script_dir}/data.json" "${script_dir}/.data.json"
+  info_msg "Copying data.json"
+  cp -v "${script_dir}/data.json" "${script_dir}/.data.json"
 
-	info_msg "Replacing variables in .data.json"
-	sed -i "s/%%openssl%%/${OPENSSL_VERSION}/g" "${script_dir}/.data.json"
-	sed -i "s/%%nginx%%/${NGINX_VERSION}/g" "${script_dir}/.data.json"
+  info_msg "Replacing variables in .data.json"
+  sed -i "s/%%openssl%%/${OPENSSL_VERSION}/g" "${script_dir}/.data.json"
+  sed -i "s/%%nginx%%/${NGINX_VERSION}/g" "${script_dir}/.data.json"
 
-	info_msg ".data.json diff:\n $(diff --color data.json .data.json)"
+  info_msg ".data.json diff:\n $(diff --color data.json .data.json)"
 
-	# Set docker repository
-	docker_repo=$(jq -r '.docker.repository' data.json)
+  # Set docker repository
+  docker_repo=$(jq -r '.docker.repository' data.json)
 
-	# Load images from data JSON to Bash list
-	local images=($(jq -r '.images[]|.name' .data.json))
+  # Load images from data JSON to Bash list
+  local images=($(jq -r '.images[]|.name' .data.json))
 
-	# Loop through all images in list
-	for image in "${images[@]}"; do
-		info_msg "Building $image for $docker_repo"
+  # Loop through all images in list
+  for image in "${images[@]}"; do
+    info_msg "Building $image for $docker_repo"
 
-		# Load tags for image from data JSON to Bash list
-		local tags=($(jq -r ".images[] | select(.name == \"${image}\") | .tags | join (\" \")" .data.json))
-		local dockerfile="$(jq -r ".images[] | select(.name == \"${image}\") | .dockerfile" .data.json)"
-		local full_img_name="${docker_repo}:${image}"
+    # Load tags for image from data JSON to Bash list
+    local tags
+    local dockerfile
+    local full_img_name
 
-		# Build image
-		info_msg "Building ${full_img_name}"
-		docker build --progress plain \
-			--build-arg="OPENSSL_VERSION=openssl-${OPENSSL_VERSION}" \
-			--build-arg="NGINX_VERSION=${NGINX_VERSION}" \
-			-f "${dockerfile}" \
-			--tag "${full_img_name}" \
-			. &&
-			success_msg "Image ${full_img_name} build sucess" ||
-			failed_builds="${failed_builds} ${full_img_name}"
+    tags=($(jq -r ".images[] | select(.name == \"${image}\") | .tags | join (\" \")" .data.json))
+    dockerfile="$(jq -r ".images[] | select(.name == \"${image}\") | .dockerfile" .data.json)"
+    full_img_name="${docker_repo}:${image}"
 
-		# Loop through all tags in list
-		for tag in "${tags[@]}"; do
-			info_msg "Retaging ${full_img_name} to ${docker_repo}:${tag}"
+    # Build image
+    info_msg "Building ${full_img_name}"
+    docker build --progress plain \
+      --build-arg="OPENSSL_VERSION=openssl-${OPENSSL_VERSION}" \
+      --build-arg="NGINX_VERSION=${NGINX_VERSION}" \
+      -f "${dockerfile}" \
+      --tag "${full_img_name}" \
+      . &&
+      success_msg "Image ${full_img_name} build sucess" ||
+      failed_builds="${failed_builds} ${full_img_name}"
 
-			# Retag image with all alternative tags
-			docker tag "${full_img_name}" "${docker_repo}:${tag}" &&
-				success_msg "Sucessfully retagged ${full_img_name} to ${docker_repo}:${tag}" ||
-				error_msg "Failed to retag ${full_img_name} to ${docker_repo}:${tag}" 1
+    # Loop through all tags in list
+    for tag in "${tags[@]}"; do
+      info_msg "Retaging ${full_img_name} to ${docker_repo}:${tag}"
 
-			# Check if --no-push tag was passed
-			if [ -z "$no_push" ]; then
-				# Push retagged image
-				docker push "${docker_repo}:${tag}" &&
-					success_msg "Sucessfully pushed ${docker_repo}:${tag}" ||
-					error_msg "Failed to push ${docker_repo}:${tag}" 1
-			else
-				warning_msg "Not pushing image since --no-push flag was passed"
-			fi
-		done
-		success_msg "Succesfully built and pushed $image for $docker_repo"
-	done
-	success_msg "Succesfully finished built procedure"
+      # Retag image with all alternative tags
+      docker tag "${full_img_name}" "${docker_repo}:${tag}" &&
+        success_msg "Sucessfully retagged ${full_img_name} to ${docker_repo}:${tag}" ||
+        error_msg "Failed to retag ${full_img_name} to ${docker_repo}:${tag}" 1
+
+      # Check if --no-push tag was passed
+      if [ -z "$no_push" ]; then
+        # Push retagged image
+        docker push "${docker_repo}:${tag}" &&
+          success_msg "Sucessfully pushed ${docker_repo}:${tag}" ||
+          error_msg "Failed to push ${docker_repo}:${tag}" 1
+      else
+        warning_msg "Not pushing image since --no-push flag was passed"
+      fi
+    done
+    success_msg "Succesfully built and pushed $image for $docker_repo"
+  done
+  success_msg "Succesfully finished built procedure"
 }
 
 function fetch_version_openssl {
-	# Get latest OpenSSL version and print result
+  # Get latest OpenSSL version and print result
 
-	curl -s "https://api.github.com/repos/openssl/openssl/tags" |
-		# Get all tag names
-		jq -r '.[]|.name' |
-		# Get "openssl-3.x.x" pattern
-		grep -P -m 1 'openssl-3\.[0-9]+\.[0-9]+$' |
-		# Get version number after "openssl-"
-		cut -d "-" -f2
+  curl -s "https://api.github.com/repos/openssl/openssl/tags" |
+    # Get all tag names
+    jq -r '.[]|.name' |
+    # Get "openssl-3.x.x" pattern
+    grep -P -m 1 'openssl-3\.[0-9]+\.[0-9]+$' |
+    # Get version number after "openssl-"
+    cut -d "-" -f2
 }
 
 function fetch_version_nginx {
-	# Get latest Nginx version and print result
+  # Get latest Nginx version and print result
 
-	curl -s "https://api.github.com/repos/nginx/nginx/tags" |
-		# Get all tag names
-		jq -r '.[]|.name' |
-		# Get first "release-x.x.x" match
-		grep -P -m 1 'release-[0-9]+\.[0-9]+\.[0-9]+$' |
-		# Get version number after "release-"
-		cut -d "-" -f2
+  curl -s "https://api.github.com/repos/nginx/nginx/tags" |
+    # Get all tag names
+    jq -r '.[]|.name' |
+    # Get first "release-x.x.x" match
+    grep -P -m 1 'release-[0-9]+\.[0-9]+\.[0-9]+$' |
+    # Get version number after "release-"
+    cut -d "-" -f2
 }
 
 function fetch_versions {
-	# Check for required commands
-	command -v sponge >/dev/null || error_msg "Please install sponge utility from moreutils package"
-	command -v jq >/dev/null || error_msg "Please install jq JSON parser package"
-	command -v curl >/dev/null || error_msg "Please install curl"
+  # Check for required commands
+  command -v sponge >/dev/null || error_msg "Please install sponge utility from moreutils package"
+  command -v jq >/dev/null || error_msg "Please install jq JSON parser package"
+  command -v curl >/dev/null || error_msg "Please install curl"
 
-	info_msg "Fetching versions"
+  info_msg "Fetching versions"
 
-	# Get latest openssl version
-	local openssl_version=$(fetch_version_openssl)
+  local nginx_version
+  local openssl_version
 
-	# Get latest nginx version
-	local nginx_version=$(fetch_version_nginx)
+  # Get latest openssl version
+  openssl_version=$(fetch_version_openssl)
 
-	info_msg "Fetched latest versions:"
-	info_msg "OpenSSL $openssl_version"
-	info_msg "Nginx $nginx_version"
+  # Get latest nginx version
+  nginx_version=$(fetch_version_nginx)
 
-	[[ "$nginx_version" != $(jq -r '.versions.nginx' data.json) ]] &&
-		warning_msg "New Nginx version" &&
-		version_trigger=1 ||
-		success_msg "Nginx version unchaged"
+  info_msg "Fetched latest versions:"
+  info_msg "OpenSSL $openssl_version"
+  info_msg "Nginx $nginx_version"
 
-	[[ "$openssl_version" != $(jq -r '.versions.openssl' data.json) ]] &&
-		warning_msg "New OpenSSL version" &&
-		version_trigger=1 ||
-		success_msg "OpenSSL version unchaged"
+  [[ "$nginx_version" != $(jq -r '.versions.nginx' data.json) ]] &&
+    warning_msg "New Nginx version" &&
+    version_trigger=1 ||
+    success_msg "Nginx version unchaged"
 
-	[[ -n "$version_trigger" ]] && warning_msg "New Version detected"
+  [[ "$openssl_version" != $(jq -r '.versions.openssl' data.json) ]] &&
+    warning_msg "New OpenSSL version" &&
+    version_trigger=1 ||
+    success_msg "OpenSSL version unchaged"
 
-	# Save version data to json
-	jq ".versions.openssl=\"$openssl_version\"" data.json | sponge data.json
-	jq ".versions.nginx=\"$nginx_version\"" data.json | sponge data.json
+  [[ -n "$version_trigger" ]] && warning_msg "New Version detected"
 
-	success_msg "All versions fetched and saved to data.json file"
+  # Save version data to json
+  jq ".versions.openssl=\"$openssl_version\"" data.json | sponge data.json
+  jq ".versions.nginx=\"$nginx_version\"" data.json | sponge data.json
 
-	# If no_build is undefined and version_trigger is not empty
-	if [ -z "$no_build" ] && [ -n "$version_trigger" ]; then
-		warning_msg "Build triggered"
-		build_images
-	elif [ -n "$version_trigger" ]; then
-		warning_msg "Version change detected but build not triggered"
-	else
-		success_msg "Build not triggered"
-	fi
+  success_msg "All versions fetched and saved to data.json file"
+
+  # If no_build is undefined and version_trigger is not empty
+  if [ -z "$no_build" ] && [ -n "$version_trigger" ]; then
+    warning_msg "Build triggered"
+    build_images
+  elif [ -n "$version_trigger" ]; then
+    warning_msg "Version change detected but build not triggered"
+  else
+    success_msg "Build not triggered"
+  fi
 }
 
 # Run Command parser
 case $script_command in
 build)
-	build_images
-	shift # shift argument
-	;;
+  build_images
+  shift # shift argument
+  ;;
 fetch)
-	fetch_versions
-	shift # shift argument
-	;;
+  fetch_versions
+  shift # shift argument
+  ;;
 fetch-openssl)
-	fetch_version_openssl
-	shift # shift argument
-	;;
+  fetch_version_openssl
+  shift # shift argument
+  ;;
 fetch-nginx)
-	fetch_version_nginx
-	shift # shift argument
-	;;
+  fetch_version_nginx
+  shift # shift argument
+  ;;
 *)
-	error_msg "Unknown command '$script_command'"
-	error_msg "Please see list of commands that you can run in help"
-	exit 1
-	;;
+  error_msg "Unknown command '$script_command'"
+  error_msg "Please see list of commands that you can run in help"
+  exit 1
+  ;;
 esac
 
 # Check for failed variables and output bad exit code
 if [ -n "$failed_builds" ]; then
-	error_msg "Some builds were not sucessfull:\n${YELLOW}${failed_builds}"
-	exit 1
+  error_msg "Some builds were not sucessfull:\n${YELLOW}${failed_builds}"
+  exit 1
 fi
 
 exit 0

--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 script_version="0.1"
 script_dir="$(dirname "$(realpath "$0")")"
@@ -6,15 +7,28 @@ script_dir="$(dirname "$(realpath "$0")")"
 # Run all commands by default
 script_command=fetch
 
-# COLORS
-ncolors=$(command -v tput >/dev/null && tput colors) # supports color
-if [[ -n $ncolors && -z $NO_COLOR ]]; then
-  TERMCOLS=$(tput cols)
-  CLEAR="$(tput sgr0)"
+# Global flags (set by argument parser)
+verbose=""
+no_build=""
+no_push=""
+failed_builds=""
 
-  # 4 bit colors
-  if test $ncolors -ge 8; then
-    # Normal
+# Clean up temp file on exit
+trap 'rm -f "${script_dir}/.data.json"' EXIT
+
+# COLORS — initialize all vars so set -u is satisfied
+CLEAR="" BOLD=""
+BLACK="" RED="" GREEN="" YELLOW="" BLUE="" MAGENTA="" CYAN="" GREY=""
+BLACK_I="" RED_I="" GREEN_I="" YELLOW_I="" BLUE_I="" MAGENTA_I="" CYAN_I="" WHITE=""
+TERMCOLS=80
+
+if command -v tput >/dev/null 2>&1 && [[ -z ${NO_COLOR:-} ]]; then
+  ncolors=$(tput colors 2>/dev/null || echo 0)
+  TERMCOLS=$(tput cols 2>/dev/null || echo 80)
+  CLEAR="$(tput sgr0)"
+  BOLD="$(tput bold)"
+
+  if [[ $ncolors -ge 8 ]]; then
     BLACK="$(tput setaf 0)"
     RED="$(tput setaf 1)"
     GREEN="$(tput setaf 2)"
@@ -25,9 +39,7 @@ if [[ -n $ncolors && -z $NO_COLOR ]]; then
     GREY="$(tput setaf 7)"
   fi
 
-  # >4 bit colors
-  if test $ncolors -gt 8; then
-    # High intensity
+  if [[ $ncolors -gt 8 ]]; then
     BLACK_I="$(tput setaf 8)"
     RED_I="$(tput setaf 9)"
     GREEN_I="$(tput setaf 10)"
@@ -46,17 +58,11 @@ if [[ -n $ncolors && -z $NO_COLOR ]]; then
     CYAN_I=$CYAN
     WHITE=$GREY
   fi
-
-  # Styles
-  BOLD="$(tput bold)"
 fi
 
 function error_msg() {
-  # Error message
-  # $1            - Message string argument
-  # $2 (optional) - exit code
   echo -e "${RED}${BOLD}[X] ${1}${CLEAR}"
-  [[ -n $2 ]] && exit $2
+  [[ -n ${2:-} ]] && exit "$2"
 }
 
 function warning_msg() {
@@ -68,8 +74,7 @@ function success_msg() {
 }
 
 function info_msg() {
-  # Info message if $verbose is set
-  [ -n "$verbose" ] && echo -e "${CYAN}[i] ${*}${CLEAR}"
+  [[ -n "$verbose" ]] && echo -e "${CYAN}[i] ${*}${CLEAR}"
 }
 
 # Display Help
@@ -83,7 +88,7 @@ help() {
   echo -e "./script.sh [build|fetch|all] [-h|v|n] [-p] [ARG]"
   echo
   echo -e "${YELLOW}EXAMPLE${CLEAR}"
-  echo -e "Build all docker images without pusshing with verbose output"
+  echo -e "Build all docker images without pushing with verbose output"
   echo -e "./script.sh build --no-push -v"
   echo
   echo -e "${YELLOW}COMMANDS${CLEAR}"
@@ -98,57 +103,53 @@ help() {
   echo -e "-b --no-build       Don't trigger build if new version is available"
   echo -e "-n --no-push        Don't push images, only build"
   echo
-  echo -e "${GREEN}${TERMCOLS} colors ${CLEAR}"
+  echo -e "${GREEN}${TERMCOLS} colors${CLEAR}"
 }
 
 # ARG parser
-if [ $# -eq 0 ]; then
-  # If no arguments, display help
+if [[ $# -eq 0 ]]; then
   help
 else
-  while [ $# -gt 0 ]; do
+  while [[ $# -gt 0 ]]; do
     case $1 in
     build)
       script_command=build
-      shift # shift argument
+      shift
       ;;
     fetch)
       script_command=fetch
-      shift # shift argument
+      shift
       ;;
     fetch-openssl)
       script_command=fetch-openssl
-      shift # shift argument
+      shift
       ;;
     fetch-nginx)
       script_command=fetch-nginx
-      shift # shift argument
+      shift
       ;;
     --help | -h)
       help
-      shift # shift argument
       exit 0
       ;;
     --verbose | -v)
       verbose=true
-      shift # shift argument
+      shift
       ;;
     --no-build | -b)
       no_build=true
-      shift # shift argument
+      shift
       ;;
     --no-push | -n)
       no_push=true
-      shift # shift argument
+      shift
       ;;
     -*)
       error_msg "Unknown option $1" 22
-      exit 1
       ;;
     *)
       error_msg "Unknown argument $1"
-      echo 'If you want to pass an argument with spaces'
-      echo 'pass the argument like this: "my argument"'
+      echo 'If you want to pass an argument with spaces, quote it: "my argument"'
       exit 1
       ;;
     esac
@@ -156,144 +157,114 @@ else
 fi
 
 function build_images {
-  # Check for required commands
-  command -v jq >/dev/null || error_msg "Please install jq JSON parser package"
+  command -v jq >/dev/null || error_msg "Please install jq JSON parser package" 1
 
-  # Set versions
+  local OPENSSL_VERSION NGINX_VERSION docker_repo
   OPENSSL_VERSION=$(jq -r '.versions.openssl' data.json)
   NGINX_VERSION=$(jq -r '.versions.nginx' data.json)
 
-  info_msg "Copying data.json"
-  cp -v "${script_dir}/data.json" "${script_dir}/.data.json"
-
-  info_msg "Replacing variables in .data.json"
+  info_msg "Preparing substituted build config"
+  cp "${script_dir}/data.json" "${script_dir}/.data.json"
   sed -i "s/%%openssl%%/${OPENSSL_VERSION}/g" "${script_dir}/.data.json"
   sed -i "s/%%nginx%%/${NGINX_VERSION}/g" "${script_dir}/.data.json"
 
-  info_msg ".data.json diff:\n $(diff --color data.json .data.json)"
+  info_msg ".data.json diff:\n $(diff --color data.json .data.json || true)"
 
-  # Set docker repository
-  docker_repo=$(jq -r '.docker.repository' data.json)
+  docker_repo=$(jq -r '.docker.repository' .data.json)
 
-  # Load images from data JSON to Bash list
-  local images=($(jq -r '.images[]|.name' .data.json))
+  local images=()
+  mapfile -t images < <(jq -r '.images[]|.name' .data.json)
 
-  # Loop through all images in list
   for image in "${images[@]}"; do
     info_msg "Building $image for $docker_repo"
 
-    # Load tags for image from data JSON to Bash list
-    local tags
-    local dockerfile
-    local full_img_name
+    local tags=() dockerfile tag_args=()
+    mapfile -t tags < <(jq -r ".images[] | select(.name == \"${image}\") | .tags[]" .data.json)
+    dockerfile=$(jq -r ".images[] | select(.name == \"${image}\") | .dockerfile" .data.json)
 
-    tags=($(jq -r ".images[] | select(.name == \"${image}\") | .tags | join (\" \")" .data.json))
-    dockerfile="$(jq -r ".images[] | select(.name == \"${image}\") | .dockerfile" .data.json)"
-    full_img_name="${docker_repo}:${image}"
+    for tag in "${tags[@]}"; do
+      tag_args+=(--tag "${docker_repo}:${tag}")
+    done
 
-    # Build image
-    info_msg "Building ${full_img_name}"
-    docker build --progress plain \
+    local push_args=()
+    if [[ -z "${no_push}" ]]; then
+      push_args=(--push)
+    else
+      warning_msg "Not pushing $image (--no-push flag was passed)"
+    fi
+
+    docker buildx build --progress plain \
+      "${push_args[@]+"${push_args[@]}"}" \
+      "${tag_args[@]}" \
       --build-arg="OPENSSL_VERSION=openssl-${OPENSSL_VERSION}" \
       --build-arg="NGINX_VERSION=${NGINX_VERSION}" \
       -f "${dockerfile}" \
-      --tag "${full_img_name}" \
       . &&
-      success_msg "Image ${full_img_name} build sucess" ||
-      failed_builds="${failed_builds} ${full_img_name}"
-
-    # Loop through all tags in list
-    for tag in "${tags[@]}"; do
-      info_msg "Retaging ${full_img_name} to ${docker_repo}:${tag}"
-
-      # Retag image with all alternative tags
-      docker tag "${full_img_name}" "${docker_repo}:${tag}" &&
-        success_msg "Sucessfully retagged ${full_img_name} to ${docker_repo}:${tag}" ||
-        error_msg "Failed to retag ${full_img_name} to ${docker_repo}:${tag}" 1
-
-      # Check if --no-push tag was passed
-      if [ -z "$no_push" ]; then
-        # Push retagged image
-        docker push "${docker_repo}:${tag}" &&
-          success_msg "Sucessfully pushed ${docker_repo}:${tag}" ||
-          error_msg "Failed to push ${docker_repo}:${tag}" 1
-      else
-        warning_msg "Not pushing image since --no-push flag was passed"
-      fi
-    done
-    success_msg "Succesfully built and pushed $image for $docker_repo"
+      success_msg "Image ${image} built${push_args:+ and pushed}" ||
+      failed_builds="${failed_builds} ${image}"
   done
-  success_msg "Succesfully finished built procedure"
+
+  success_msg "Build procedure finished"
 }
 
 function fetch_version_openssl {
-  # Get latest OpenSSL version and print result
-
   curl -s "https://api.github.com/repos/openssl/openssl/tags" |
-    # Get all tag names
     jq -r '.[]|.name' |
-    # Get "openssl-3.x.x" pattern
     grep -P -m 1 'openssl-3\.[0-9]+\.[0-9]+$' |
-    # Get version number after "openssl-"
     cut -d "-" -f2
 }
 
 function fetch_version_nginx {
-  # Get latest Nginx version and print result
-
   curl -s "https://api.github.com/repos/nginx/nginx/tags" |
-    # Get all tag names
     jq -r '.[]|.name' |
-    # Get first "release-x.x.x" match
     grep -P -m 1 'release-[0-9]+\.[0-9]+\.[0-9]+$' |
-    # Get version number after "release-"
     cut -d "-" -f2
 }
 
 function fetch_versions {
-  # Check for required commands
-  command -v sponge >/dev/null || error_msg "Please install sponge utility from moreutils package"
-  command -v jq >/dev/null || error_msg "Please install jq JSON parser package"
-  command -v curl >/dev/null || error_msg "Please install curl"
+  command -v jq >/dev/null || error_msg "Please install jq JSON parser package" 1
+  command -v curl >/dev/null || error_msg "Please install curl" 1
 
   info_msg "Fetching versions"
 
-  local nginx_version
-  local openssl_version
+  local openssl_version nginx_version version_trigger=""
 
-  # Get latest openssl version
   openssl_version=$(fetch_version_openssl)
-
-  # Get latest nginx version
   nginx_version=$(fetch_version_nginx)
 
   info_msg "Fetched latest versions:"
   info_msg "OpenSSL $openssl_version"
   info_msg "Nginx $nginx_version"
 
-  [[ "$nginx_version" != $(jq -r '.versions.nginx' data.json) ]] &&
-    warning_msg "New Nginx version" &&
-    version_trigger=1 ||
-    success_msg "Nginx version unchaged"
+  if [[ "$nginx_version" != "$(jq -r '.versions.nginx' data.json)" ]]; then
+    warning_msg "New Nginx version: $nginx_version"
+    version_trigger=1
+  else
+    success_msg "Nginx version unchanged"
+  fi
 
-  [[ "$openssl_version" != $(jq -r '.versions.openssl' data.json) ]] &&
-    warning_msg "New OpenSSL version" &&
-    version_trigger=1 ||
-    success_msg "OpenSSL version unchaged"
+  if [[ "$openssl_version" != "$(jq -r '.versions.openssl' data.json)" ]]; then
+    warning_msg "New OpenSSL version: $openssl_version"
+    version_trigger=1
+  else
+    success_msg "OpenSSL version unchanged"
+  fi
 
-  [[ -n "$version_trigger" ]] && warning_msg "New Version detected"
+  [[ -n "$version_trigger" ]] && warning_msg "New version detected"
 
-  # Save version data to json
-  jq ".versions.openssl=\"$openssl_version\"" data.json | sponge data.json
-  jq ".versions.nginx=\"$nginx_version\"" data.json | sponge data.json
+  # Save both version updates atomically
+  local tmp
+  tmp=$(mktemp)
+  jq --arg openssl "$openssl_version" --arg nginx "$nginx_version" \
+    '.versions.openssl=$openssl | .versions.nginx=$nginx' \
+    data.json >"$tmp" && mv "$tmp" data.json
 
-  success_msg "All versions fetched and saved to data.json file"
+  success_msg "Versions saved to data.json"
 
-  # If no_build is undefined and version_trigger is not empty
-  if [ -z "$no_build" ] && [ -n "$version_trigger" ]; then
+  if [[ -z "$no_build" && -n "$version_trigger" ]]; then
     warning_msg "Build triggered"
     build_images
-  elif [ -n "$version_trigger" ]; then
+  elif [[ -n "$version_trigger" ]]; then
     warning_msg "Version change detected but build not triggered"
   else
     success_msg "Build not triggered"
@@ -304,31 +275,25 @@ function fetch_versions {
 case $script_command in
 build)
   build_images
-  shift # shift argument
   ;;
 fetch)
   fetch_versions
-  shift # shift argument
   ;;
 fetch-openssl)
   fetch_version_openssl
-  shift # shift argument
   ;;
 fetch-nginx)
   fetch_version_nginx
-  shift # shift argument
   ;;
 *)
   error_msg "Unknown command '$script_command'"
-  error_msg "Please see list of commands that you can run in help"
+  error_msg "Please see list of commands in help"
   exit 1
   ;;
 esac
 
-# Check for failed variables and output bad exit code
-if [ -n "$failed_builds" ]; then
-  error_msg "Some builds were not sucessfull:\n${YELLOW}${failed_builds}"
-  exit 1
+if [[ -n "$failed_builds" ]]; then
+  error_msg "Some builds were not successful:${YELLOW}${failed_builds}" 1
 fi
 
 exit 0


### PR DESCRIPTION
New images:
- debian-trixie/Dockerfile: base image with OpenSSL + GOST engine on debian:trixie-slim
- debian-trixie/nginx.Dockerfile: adds nginx built against the custom OpenSSL
- data.json: register trixie and trixie-nginx images with their respective tags
- README.md: document new trixie/* tags under supported images

script.sh modernization:
- Switch shebang to #!/usr/bin/env bash and add set -euo pipefail
- Initialize all globals (verbose, no_build, no_push, failed_builds) so set -u is satisfied
- Initialize all color/tput variables before the tput block to avoid unbound-variable errors
  in environments without a terminal; guard tput calls with 2>/dev/null fallbacks
- Add trap to clean up .data.json on any exit
- Replace unsafe arr=($(...)) word-splitting with mapfile -t for image and tag arrays
- Replace the old build → separate tag-loop → separate push-loop pattern with a single
  docker buildx build call passing all --tag flags at once plus --push
- Replace sponge (moreutils) with mktemp + mv; combine both jq version updates into
  one atomic call using --arg
- Convert &&/|| version-comparison chains to explicit if/else for clarity
- Fix typos (pusshing, unchaged, Succesfully, sucess)

CI workflow modernization (.github/workflows/docker-hub.yml):
- Fix cron expression: "1 */24 * * *" → "1 0 * * *" (daily at 00:01, not rolling 24h)
- Add concurrency block to cancel in-progress runs on new pushes
- Add docker/setup-buildx-action@v3 step (required for docker buildx build)
- Drop moreutils from apt-get install (sponge no longer used)
- Bump stefanzweifel/git-auto-commit-action v4 → v5

Services:
- server: mbrav/docker-gost:bookworm-nginx, listens on :443 with GOST TLS.
  A self-signed GOST 2012 certificate (gost2012_256, paramset A) is generated
  by entrypoint.sh on first start and persisted in a named volume so the
  certificate survives container restarts.
- proxy: mbrav/docker-gost:bookworm-nginx, listens on :8080 (plain HTTP).
  Connects to server:443 using GOST cipher suites and re-serves content in
  cleartext, allowing access from a standard browser without GOST support.
  Uses Docker's embedded DNS resolver (127.0.0.11) for dynamic upstream
  resolution and proxy_ssl_ciphers to negotiate the GOST handshake.

Files added:
- docker-compose.yml: service definitions with healthcheck on the server
  (openssl s_client probe) and depends_on: service_healthy on the proxy
- entrypoint.sh: generates key + CSR + self-signed cert if absent, then
  execs nginx
- nginx/server.nginx.conf: TLSv1.2-only, GOST cipher suite, serves
  /var/www/html
- nginx/proxy.nginx.conf: HTTP reverse proxy with proxy_ssl_ciphers set
  to GOST suites for the upstream connection
- html/index.html: demo page showing active cipher suites and inspection
  commands
- README.md: architecture diagram, usage instructions, cert details table
